### PR TITLE
OS-7321 QEMU occasionally forgets to send a NOTIFY_ON_EMPTY interrupt

### DIFF
--- a/hw/virtio-net.c
+++ b/hw/virtio-net.c
@@ -199,7 +199,7 @@ static void virtio_net_rein_tick(void *opaque)
 		return;
 	}
 
-	ret = virtqueue_stalled(n->tx_vq);
+	ret = virtqueue_stalled(&n->vdev, n->tx_vq);
 	if (ret == 1) {
 		virtio_net_rein_event(n, REIN_INJECT, n->rein_timer_ticks);
 		virtio_net_rein_disable(n);

--- a/hw/virtio.h
+++ b/hw/virtio.h
@@ -226,6 +226,6 @@ EventNotifier *virtio_queue_get_guest_notifier(VirtQueue *vq);
 EventNotifier *virtio_queue_get_host_notifier(VirtQueue *vq);
 void virtio_queue_notify_vq(VirtQueue *vq);
 void virtio_irq(VirtQueue *vq);
-int virtqueue_stalled(VirtQueue *vq);
+int virtqueue_stalled(VirtIODevice *vdev, VirtQueue *vq);
 int virtqueue_handled(VirtQueue *vq);
 #endif


### PR DESCRIPTION
Reviewed by: Rui Loura <rui.loura@joyent.com>
Reviewed by: Robert Mustacchi <rm@joyent.com>
Approved by: Robert Mustacchi <rm@joyent.com>